### PR TITLE
Fix to work well when remounting elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+<!-- ### Added -->
+<!-- ### Changed -->
+<!-- ### Removed -->
+
+### Fixed
+
+- Fix a bug `useEffect` does not work when remounted. ([#20](https://github.com/wtnbass/fuco/pull/20))

--- a/src/__tests__/effect_test.ts
+++ b/src/__tests__/effect_test.ts
@@ -58,5 +58,23 @@ describe(
       expect(cleanupCount).toEqual(0);
       expect(updateCount).toEqual(1);
     });
+
+    it("cleanup works well", async () => {
+      const target = await f.setup();
+      expect(updateCount).toEqual(1);
+      expect(cleanupCount).toEqual(0);
+
+      f.unmount();
+
+      await waitFor();
+      expect(updateCount).toEqual(1);
+      expect(cleanupCount).toEqual(1);
+
+      document.body.appendChild(target);
+
+      await waitFor();
+      expect(updateCount).toEqual(2);
+      expect(cleanupCount).toEqual(1);
+    });
   })
 );

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -23,15 +23,19 @@ export function hooks<T>(config: {
   return h.values[index];
 }
 
-export abstract class Component extends HTMLElement {
-  private updating = false;
-  public $root = this.attachShadow({ mode: "open" });
-  public hooks: Hooks<unknown> = {
+function createHooks(): Hooks<unknown> {
+  return {
     values: [],
     deps: [],
     effects: [],
     cleanup: []
   };
+}
+
+export abstract class Component extends HTMLElement {
+  private updating = false;
+  public $root = this.attachShadow({ mode: "open" });
+  public hooks = createHooks();
 
   protected abstract render(): void;
 
@@ -41,6 +45,7 @@ export abstract class Component extends HTMLElement {
 
   protected disconnectedCallback() {
     this.hooks.cleanup.forEach(f => f());
+    this.hooks = createHooks();
   }
 
   public update() {


### PR DESCRIPTION
## Description

`useEffect` does not work when remounted.

```
defineElement("effect-element", () => {
  useEffect(() => {
    console.log("mounted");
    return () => console.log("unmounted")
  }, []);
});

// On other element
html`
  ${cache(condition ? html`
    <effect-element></effect-element>
  ` : html``
  }
`
```
