### PR TITLE
Using puppeteer for ChromeHeadless

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+process.env.CHROME_BIN = require("puppeteer").executablePath();
+
 module.exports = function(config) {
   config.set({
     frameworks: ["jasmine"],

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "karma-jasmine": "2.0.1",
     "karma-webpack": "4.0.2",
     "prettier": "1.18.2",
+    "puppeteer": "1.19.0",
     "rollup": "1.16.7",
     "rollup-plugin-copy": "3.0.0",
     "rollup-plugin-filesize": "6.1.1",


### PR DESCRIPTION
## Problem

Testing with karma on headless chrome is frequently failed.
```
Disconnectedreconnect failed before timeout of 2000ms (transport error)
```

So, I tried [using puppeteer to run tests on headless chrome](https://github.com/karma-runner/karma-chrome-launcher#headless-chromium-with-puppeteer).
